### PR TITLE
Update/api interface spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 venv
 .DS_Store
 .ipynb_checkpoints
+.idea
 
 # build / dist
 __pycache__

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,0 @@
-# Changelog
-
-## v1/
-
-- Initialize specifications

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -285,3 +285,5 @@ optional value of altitude
 ([ref](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1))
 
 e.g. \[165.5,63.12, 10363\]. The altitude value is in units of *meters*.
+
+## Changelog

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -266,6 +266,9 @@ The threshold value provided by the client must be one of the following:
 
 Same as [grids.error_handling](#error-handling)
 
+## response headers
+Same as [grids.response_headers](#response-headers)
+
 ### response object
 
 The geoJSON object returned is a FeatureCollection, with the following

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -120,15 +120,6 @@ If multiple candidate URIs exist for a given timestamp at the time of
 the client request, the API should return the URI whose outputs were
 generated using the nearest forecast time.
 
-Additionally, the following values must be populated in the response
-header, to contextualize the nature of the data in the response
-(imperative since the behavior of the API is not idempotent given the
-above-mentioned behavior).
-
-- `model_forecast_hour`: `<int>`
-- `model_prediction_at`: `<%Y-%m-%dT%H:%M:%S>`
-- `model_run_at`: `<%Y-%m-%dT%H:%M:%S>`
-
 ### flight level
 
 The fl value represents the flight level (*hectofeet*) of the returned
@@ -150,6 +141,25 @@ A 422 status code and informative message should be returned if:
 A 400 status code and informative message should be returned if:
 
 - the request is properly formed and interpretable, but the requested resource does not exist
+
+### response headers
+The following values must be populated in the response
+header, to contextualize the nature of the data in the response
+(imperative since the behavior of the API is not idempotent given the
+above-mentioned behavior).
+
+- `model_run_at`: `<%Y-%m-%dT%H:%M:%S>`
+- `model_prediction_at`: `<%Y-%m-%dT%H:%M:%S>`
+- `model_forecast_hour`: `<int>`
+
+`model_run_at` is the time at which the HRES meteorological model was executed,
+for those HRES forecasts used in running the CoCip model.
+
+`model_predicted_at` is the time of the CoCip model prediction. i.e. it is the same as the `<ts>` value
+passed in the API call, and the `time` of the data returned in the gridded netCDF.
+
+`model_forecast_hour` is the difference, in hours, between `model_predicted_at` and `model_run_at`.
+It represents how far out the meteorological forecast is for a given CoCip output.
 
 ### response object
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -31,7 +31,7 @@ availability.
     existing in the range of \[0, 4]\, `0` being a location with no contrail impact, 
     and `4` being a location with severe contrail impact.  The value of `contrails`
     is intended to scale, roughly, with the CO2 equivalence of contrail impact, and by extension,
-    scale with the equivalent fuel penalty for avoiding a given region.
+    the appropriate fuel investment for avoiding a given region.
     i.e. one should be willing to burn 2x as much fuel to avoid a location with `contrails` of `3`
     over a region with `contrails` of `1.5`.
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -176,7 +176,7 @@ Attributes:
     aircraft_class: "default"
 ```
 
-Note that `forecast_reference_time` in the dataset level *Attributes* is has the same definition as
+Note that `forecast_reference_time` in the dataset level *Attributes* has the same definition as
 `model_run_at` in the API response header.
 See the [Forecast Data spec](forecast-data.md) for more info.
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -171,15 +171,19 @@ Coordinates:
   * time       (time) datetime64[ns] 8B 2024-07-01T12:00:00
 Data variables:
     contrails   (longitude, latitude, flight_level, time) float32 4MB ...
+Attributes:
+    forecast_reference_time:  "2024-07-01T06:00:00Z"
+    aircraft_class: "default"
 ```
 
-Note that there are no dataset level *Attributes* included in the netCDF
-object.
+Note that `forecast_reference_time` in the dataset level *Attributes* is has the same definition as
+`model_run_at` in the API response header.
+See the [Forecast Data spec](forecast-data.md) for more info.
 
-The `ef_per_m` data variable has the following *Attributes*:
+The `contrails` data variable has the following *Attributes*:
 
 ```text
-<xarray.DataArray 'ef_per_m' (longitude: 1440, latitude: 641, level: 1, time: 1)> Size: 4MB
+<xarray.DataArray 'contrails' (longitude: 1440, latitude: 641, level: 1, time: 1)> Size: 4MB
 [923040 values with dtype=float32]
 Coordinates:
   * longitude  (longitude) float32 6kB -180.0 -179.8 -179.5 ... 179.5 179.8
@@ -284,7 +288,8 @@ e.g. \[165.5,63.12, 10363\]. The altitude value is in units of *meters*.
 ## Changelog
 
 ### 2024.10.09
-- `/grids` endpoint updated to return a modified netCDF file, replacing the variable `ef_per_m` with the variable `contrails`
+- `/grids` endpoint updated to return a modified netCDF file, replacing the variable `ef_per_m` with the variable `contrails`,
+and adding `forcast_reference_time` and `aircraft_class` to the netCDF global attributes.
 - `/regions` endpoint updated to return geoJSON polygons rendered with a threshold based on `contrails` rather than `ef_per_m`
   - new supported threshold include `[1, 2, 3, 4]`
 - `/regions` geoJSON response object format updated from `.features.*` to `.features[].*`.

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -21,7 +21,7 @@ avoidance systems.
 At present, this document specifies two endpoints for general
 availability.
 
-1.  **grids**: The first endpoint surfaces gridded netCDF content of at 0.25
+1.  **grids**: The first endpoint surfaces gridded netCDF content at 0.25
     degree grid spacing, across standardized flight levels, on a one
     hour interval, at all longitudes and latitudes ranging from \[-80,
     80\] (this is expected to expand and encompass the poles, with an

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -1,9 +1,3 @@
-| **Description**  | (EXTERNAL) Forecast API v1 |
-|:--|:---------------------------|
-| **Date** | October 2024               |
-| **Owner(s)** | Nick Masson                |
-| **Status**  | Complete                   |
-
 # Contrail Forecast API
 
 ## Table of Contents

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -14,9 +14,11 @@ Forecast must be globally valid for the same `forecast_reference_time`.
 
 ## Global Attributes
 
-- `forecast_reference_time` (`str`): The forecast reference time is the "data time", i.e. the time of the analysis from which the forecast was made. Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
-- `aircraft_class` (`str`): Aircraft class for forecast. One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
-- `model_version` (`str`): Model version identifier
+- `forecast_reference_time` (`str`): The forecast reference time is the "data time", 
+i.e. the time at which the meteorological model was executed for a given set of forecast times. 
+Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
+- `aircraft_class` (`str`): Aircraft class for forecast. 
+One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 
 ## Dimensions
 

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -17,8 +17,9 @@ Forecast must be globally valid for the same `forecast_reference_time`.
 - `forecast_reference_time` (`str`): The forecast reference time is the "data time", 
 i.e. the time at which the meteorological model was executed for a given set of forecast times. 
 Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
-- `aircraft_class` (`str`): Aircraft class for forecast. 
+- (optional) `aircraft_class` (`str`): Aircraft class for forecast. 
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
+- (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
 
 ## Dimensions
 

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -21,6 +21,8 @@ Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 - (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
 
+Additional attributes, in addition to the required and suggested ones above, may be added at the author's discretion.
+
 ## Dimensions
 
 - `longitude` (`float32`): `np.arange(-180, 180, 0.25)`, EPSG:4326

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -93,3 +93,5 @@ ds["contrails"] = (ds["cfi"] / 1e9) * 4
 	1 and 2 are generally carrier choice. 3 and 4 are generally ANSP mandated. Category 4 are always climate positive to avoid.
 
 [^efinterpretation]: See [Energy Forcing Interpretation](https://apidocs.contrails.org/ef-interpretation.html) for background informing example mapping from `ef_per_m` to `contrails` index.
+
+## Changelog


### PR DESCRIPTION
## Changes
Updates the forecast API spec ("interface contract"), to be consistent with our updates to the `/v1` api, moving from `ef_per_m` to our domain-agnostic/arbitary unit of `contrails`.

### Refs
[API Preprocessor (ETL backend) release](https://github.com/contrailcirrus/api-preprocessor/pull/74)

[contrails API (public REST API) release](https://github.com/contrailcirrus/contrails-api/pull/142)