### PR TITLE
Refactor/netcdf attrs

### DIFF
--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -266,6 +266,9 @@ The threshold value provided by the client must be one of the following:
 
 Same as [grids.error_handling](#error-handling)
 
+## response headers
+Same as [grids.response_headers](#response-headers)
+
 ### response object
 
 The geoJSON object returned is a FeatureCollection, with the following

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -120,15 +120,6 @@ If multiple candidate URIs exist for a given timestamp at the time of
 the client request, the API should return the URI whose outputs were
 generated using the nearest forecast time.
 
-Additionally, the following values must be populated in the response
-header, to contextualize the nature of the data in the response
-(imperative since the behavior of the API is not idempotent given the
-above-mentioned behavior).
-
-- `model_forecast_hour`: `<int>`
-- `model_prediction_at`: `<%Y-%m-%dT%H:%M:%S>`
-- `model_run_at`: `<%Y-%m-%dT%H:%M:%S>`
-
 ### flight level
 
 The fl value represents the flight level (*hectofeet*) of the returned
@@ -150,6 +141,25 @@ A 422 status code and informative message should be returned if:
 A 400 status code and informative message should be returned if:
 
 - the request is properly formed and interpretable, but the requested resource does not exist
+
+### response headers
+The following values must be populated in the response
+header, to contextualize the nature of the data in the response
+(imperative since the behavior of the API is not idempotent given the
+above-mentioned behavior).
+
+- `model_run_at`: `<%Y-%m-%dT%H:%M:%S>`
+- `model_prediction_at`: `<%Y-%m-%dT%H:%M:%S>`
+- `model_forecast_hour`: `<int>`
+
+`model_run_at` is the time at which the HRES meteorological model was executed,
+for those HRES forecasts used in running the CoCip model.
+
+`model_predicted_at` is the time of the CoCip model prediction. i.e. it is the same as the `<ts>` value
+passed in the API call, and the `time` of the data returned in the gridded netCDF.
+
+`model_forecast_hour` is the difference, in hours, between `model_predicted_at` and `model_run_at`.
+It represents how far out the meteorological forecast is for a given CoCip output.
 
 ### response object
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -176,7 +176,7 @@ Attributes:
     aircraft_class: "default"
 ```
 
-Note that `forecast_reference_time` in the dataset level *Attributes* is has the same definition as
+Note that `forecast_reference_time` in the dataset level *Attributes* has the same definition as
 `model_run_at` in the API response header.
 See the [Forecast Data spec](forecast-data.md) for more info.
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -171,15 +171,19 @@ Coordinates:
   * time       (time) datetime64[ns] 8B 2024-07-01T12:00:00
 Data variables:
     contrails   (longitude, latitude, flight_level, time) float32 4MB ...
+Attributes:
+    forecast_reference_time:  "2024-07-01T06:00:00Z"
+    aircraft_class: "default"
 ```
 
-Note that there are no dataset level *Attributes* included in the netCDF
-object.
+Note that `forecast_reference_time` in the dataset level *Attributes* is has the same definition as
+`model_run_at` in the API response header.
+See the [Forecast Data spec](forecast-data.md) for more info.
 
-The `ef_per_m` data variable has the following *Attributes*:
+The `contrails` data variable has the following *Attributes*:
 
 ```text
-<xarray.DataArray 'ef_per_m' (longitude: 1440, latitude: 641, level: 1, time: 1)> Size: 4MB
+<xarray.DataArray 'contrails' (longitude: 1440, latitude: 641, level: 1, time: 1)> Size: 4MB
 [923040 values with dtype=float32]
 Coordinates:
   * longitude  (longitude) float32 6kB -180.0 -179.8 -179.5 ... 179.5 179.8
@@ -284,7 +288,8 @@ e.g. \[165.5,63.12, 10363\]. The altitude value is in units of *meters*.
 ## Changelog
 
 ### 2024.10.09
-- `/grids` endpoint updated to return a modified netCDF file, replacing the variable `ef_per_m` with the variable `contrails`
+- `/grids` endpoint updated to return a modified netCDF file, replacing the variable `ef_per_m` with the variable `contrails`,
+and adding `forcast_reference_time` and `aircraft_class` to the netCDF global attributes.
 - `/regions` endpoint updated to return geoJSON polygons rendered with a threshold based on `contrails` rather than `ef_per_m`
   - new supported threshold include `[1, 2, 3, 4]`
 - `/regions` geoJSON response object format updated from `.features.*` to `.features[].*`.

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -14,9 +14,11 @@ Forecast must be globally valid for the same `forecast_reference_time`.
 
 ## Global Attributes
 
-- `forecast_reference_time` (`str`): The forecast reference time is the "data time", i.e. the time of the analysis from which the forecast was made. Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
-- `aircraft_class` (`str`): Aircraft class for forecast. One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
-- `model_version` (`str`): Model version identifier
+- `forecast_reference_time` (`str`): The forecast reference time is the "data time", 
+i.e. the time at which the meteorological model was executed for a given set of forecast times. 
+Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
+- `aircraft_class` (`str`): Aircraft class for forecast. 
+One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 
 ## Dimensions
 

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -17,8 +17,9 @@ Forecast must be globally valid for the same `forecast_reference_time`.
 - `forecast_reference_time` (`str`): The forecast reference time is the "data time", 
 i.e. the time at which the meteorological model was executed for a given set of forecast times. 
 Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
-- `aircraft_class` (`str`): Aircraft class for forecast. 
+- (optional) `aircraft_class` (`str`): Aircraft class for forecast. 
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
+- (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
 
 ## Dimensions
 

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -21,6 +21,8 @@ Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 - (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
 
+Additional attributes, in addition to the required and suggested ones above, may be added at the author's discretion.
+
 ## Dimensions
 
 - `longitude` (`float32`): `np.arange(-180, 180, 0.25)`, EPSG:4326


### PR DESCRIPTION
## Changes
Removes versioning from the netcdf response object attributes, and updates the API contract to be consistent with the new data contract.

Coordinated changes to the API preprocessor here: https://github.com/contrailcirrus/api-preprocessor/pull/75/files

## Discussion
Note that the `forecast_reference_time` in the netcdf attrs is the same definitionally as the `model_run_at` unixtime returned in the API response header. Including these data in both places mixes paradigms a bit (my preference being to have the API be the singular agent dictating and governing the nature of the data returned, _not_ the author, i.e. api-preprocessor, of the netcdf asset). But, I do see the practical advantage in localizing this &  echoing into the netcdf file.

Secondly, we'll use two different names for this same field. I find `forecast_reference_time` confusing, since it is the time that the _forecasting model_ was run, but the time itself isn't a _forecast_ (is "forecast" a modifier of "time" or is "forecast" a modifier of "reference", and "forecast reference" a modifier of "time" 🤷 ). But I'm OK with sticking with two different names, since it is likely that a consumer would fall into one of two camps (either referencing the header for SOT info, or the netCDF file... but prob not both).

Lastly, I think we should remove the version attribute -- I think it is not useful and an anti-pattern to provide it here.  How would we version the data for the netcdf?  Is this the pycontrails version? that wouldn't be appropriate, since there are many ways in which the numerics of the data could change, while the pycontrails version remains constant (e.g. we modify the pycontrails grid model configs).  If we're aiming to provide a version for the netcdf data, then the appropriate identifier would be the API preprocessor production release version (or git hash), since that fully constrains (versions) the data being served up. But... that information is an internal concern, so not useful to an external consumer.  IMHO, it is best to generally not pin any version designator to assets returned from a REST API's response objects, rather, let the REST API versioning (public concern) qualify the data returned.


