### PR TITLE
update doc; /regions signature; /grids signature

### DIFF
--- a/docs/notebooks/forecast-data.ipynb
+++ b/docs/notebooks/forecast-data.ipynb
@@ -32,23 +32,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2024-10-24 16:09:02--  https://drive.usercontent.google.com/download?id=1fxPe2AdmiXyucpxhj-9tAAcv0ghBWvpH&export=download\n",
-      "Resolving drive.usercontent.google.com (drive.usercontent.google.com)... 142.251.40.193\n",
-      "Connecting to drive.usercontent.google.com (drive.usercontent.google.com)|142.251.40.193|:443... connected.\n",
+      "--2024-11-13 12:38:33--  https://drive.usercontent.google.com/download?id=1HftWWr4Z9ho_mjm1kbaL35SnQS9pzyjG&export=download\n",
+      "Resolving drive.usercontent.google.com (drive.usercontent.google.com)... 142.251.41.1\n",
+      "Connecting to drive.usercontent.google.com (drive.usercontent.google.com)|142.251.41.1|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 66478157 (63M) [application/octet-stream]\n",
+      "Length: 66477996 (63M) [application/octet-stream]\n",
       "Saving to: ‘forecast.nc’\n",
       "\n",
-      "forecast.nc         100%[===================>]  63.40M  9.82MB/s    in 6.4s    \n",
+      "forecast.nc         100%[===================>]  63.40M  8.97MB/s    in 6.6s    \n",
       "\n",
-      "2024-10-24 16:09:13 (9.97 MB/s) - ‘forecast.nc’ saved [66478157/66478157]\n",
+      "2024-11-13 12:38:43 (9.57 MB/s) - ‘forecast.nc’ saved [66477996/66477996]\n",
       "\n"
      ]
     }
    ],
    "source": [
     "# download example data file\n",
-    "!wget \"https://drive.usercontent.google.com/download?id=1fxPe2AdmiXyucpxhj-9tAAcv0ghBWvpH&export=download\" -O forecast.nc"
+    "file_id = \"1HftWWr4Z9ho_mjm1kbaL35SnQS9pzyjG\"\n",
+    "!wget \"https://drive.usercontent.google.com/download?id={file_id}&export=download\" -O forecast.nc"
    ]
   },
   {
@@ -61,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "8804a2fe-2936-4bbb-8413-0cfa0a13d148",
    "metadata": {},
    "outputs": [],
@@ -71,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "fac77599-bd6d-4167-b67f-9de52cfacbbb",
    "metadata": {},
    "outputs": [
@@ -442,20 +443,21 @@
        "  fill: currentColor;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;\n",
-       "Dimensions:       (longitude: 1440, latitude: 641, flight_level: 18, time: 1)\n",
+       "Dimensions:                  (longitude: 1440, latitude: 641, flight_level: 18,\n",
+       "                              time: 1)\n",
        "Coordinates:\n",
-       "  * longitude     (longitude) float32 -180.0 -179.8 -179.5 ... 179.2 179.5 179.8\n",
-       "  * latitude      (latitude) float32 -80.0 -79.75 -79.5 ... 79.5 79.75 80.0\n",
-       "  * flight_level  (flight_level) int32 270 280 290 300 310 ... 410 420 430 440\n",
-       "  * time          (time) datetime64[ns] 2024-09-25T18:00:00\n",
+       "  * longitude                (longitude) float32 -180.0 -179.8 ... 179.5 179.8\n",
+       "  * latitude                 (latitude) float32 -80.0 -79.75 ... 79.75 80.0\n",
+       "  * flight_level             (flight_level) int32 270 280 290 ... 420 430 440\n",
+       "  * time                     (time) datetime64[ns] 2024-09-25T18:00:00\n",
+       "    forecast_reference_time  (time) datetime64[ns] 2024-09-25T12:00:00\n",
        "Data variables:\n",
-       "    contrails     (longitude, latitude, flight_level, time) float32 0.0 ... 0.0\n",
+       "    contrails                (longitude, latitude, flight_level, time) float32 ...\n",
        "Attributes:\n",
-       "    forecast_reference_time:  2024-09-25T12:00:00Z\n",
-       "    aircraft_class:           default\n",
-       "    model:                    v1</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-9ab8b5e5-a45d-490a-a760-11d031a44cc9' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-9ab8b5e5-a45d-490a-a760-11d031a44cc9' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>longitude</span>: 1440</li><li><span class='xr-has-index'>latitude</span>: 641</li><li><span class='xr-has-index'>flight_level</span>: 18</li><li><span class='xr-has-index'>time</span>: 1</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-0bc14e81-5f4d-4432-96e1-d3d049553dbe' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0bc14e81-5f4d-4432-96e1-d3d049553dbe' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.8 ... 179.5 179.8</div><input id='attrs-a3c53f1e-e757-4050-8daf-4d7203127b62' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a3c53f1e-e757-4050-8daf-4d7203127b62' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a807851d-b3da-46b4-9ada-fd857686ccc9' class='xr-var-data-in' type='checkbox'><label for='data-a807851d-b3da-46b4-9ada-fd857686ccc9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-180.  , -179.75, -179.5 , ...,  179.25,  179.5 ,  179.75],\n",
-       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.0 -79.75 -79.5 ... 79.75 80.0</div><input id='attrs-d68b1832-9906-48df-99f8-b04431d47097' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d68b1832-9906-48df-99f8-b04431d47097' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5cc4ab83-8949-4893-a780-869331a77537' class='xr-var-data-in' type='checkbox'><label for='data-5cc4ab83-8949-4893-a780-869331a77537' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-80.  , -79.75, -79.5 , ...,  79.5 ,  79.75,  80.  ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>flight_level</span></div><div class='xr-var-dims'>(flight_level)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>270 280 290 300 ... 410 420 430 440</div><input id='attrs-62ba70ce-da0b-40e7-9a77-59677d967e43' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-62ba70ce-da0b-40e7-9a77-59677d967e43' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af7b0a6e-55e9-430f-9680-4234350cdb7d' class='xr-var-data-in' type='checkbox'><label for='data-af7b0a6e-55e9-430f-9680-4234350cdb7d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Flight level</dd><dt><span>units :</span></dt><dd>hectofeet</dd></dl></div><div class='xr-var-data'><pre>array([270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400,\n",
-       "       410, 420, 430, 440], dtype=int32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2024-09-25T18:00:00</div><input id='attrs-20ff1ab9-714f-44be-91da-fd8d1073be86' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-20ff1ab9-714f-44be-91da-fd8d1073be86' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-15dccd9f-8f06-4989-9692-2a208e786387' class='xr-var-data-in' type='checkbox'><label for='data-15dccd9f-8f06-4989-9692-2a208e786387' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2024-09-25T18:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-00c1be19-3dd1-4b82-a6b4-d55bf9f85f54' class='xr-section-summary-in' type='checkbox'  checked><label for='section-00c1be19-3dd1-4b82-a6b4-d55bf9f85f54' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>contrails</span></div><div class='xr-var-dims'>(longitude, latitude, flight_level, time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0</div><input id='attrs-bcd76ce0-2176-4de7-9c22-dabc6c546744' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bcd76ce0-2176-4de7-9c22-dabc6c546744' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ee849229-1f06-4e32-bdf9-c91e64a7a571' class='xr-var-data-in' type='checkbox'><label for='data-ee849229-1f06-4e32-bdf9-c91e64a7a571' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Contrail forcing index</dd><dt><span>units :</span></dt><dd></dd><dt><span>valid_min :</span></dt><dd>0</dd><dt><span>valid_max :</span></dt><dd>4</dd></dl></div><div class='xr-var-data'><pre>array([[[[0.        ],\n",
+       "    aircraft_class:  default\n",
+       "    model:           v1</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2da9e352-6793-4c74-8b4b-9a97fd0f543a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2da9e352-6793-4c74-8b4b-9a97fd0f543a' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>longitude</span>: 1440</li><li><span class='xr-has-index'>latitude</span>: 641</li><li><span class='xr-has-index'>flight_level</span>: 18</li><li><span class='xr-has-index'>time</span>: 1</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e7cbcdf6-6b1b-41f1-a2db-31113a22a57d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e7cbcdf6-6b1b-41f1-a2db-31113a22a57d' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-180.0 -179.8 ... 179.5 179.8</div><input id='attrs-e1b7cb0f-4406-41d3-8916-8d870d86a0ad' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e1b7cb0f-4406-41d3-8916-8d870d86a0ad' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c3fa3745-f1c8-46da-acd9-65f042901e82' class='xr-var-data-in' type='checkbox'><label for='data-c3fa3745-f1c8-46da-acd9-65f042901e82' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-180.  , -179.75, -179.5 , ...,  179.25,  179.5 ,  179.75],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.0 -79.75 -79.5 ... 79.75 80.0</div><input id='attrs-7ab371be-128e-4813-9a7c-01c20daea6e2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7ab371be-128e-4813-9a7c-01c20daea6e2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1b86e38f-663d-41dc-b201-ed52844bd6a0' class='xr-var-data-in' type='checkbox'><label for='data-1b86e38f-663d-41dc-b201-ed52844bd6a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-80.  , -79.75, -79.5 , ...,  79.5 ,  79.75,  80.  ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>flight_level</span></div><div class='xr-var-dims'>(flight_level)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>270 280 290 300 ... 410 420 430 440</div><input id='attrs-7b241287-cac1-40f0-84ea-89c22b65d6ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7b241287-cac1-40f0-84ea-89c22b65d6ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b71adc7e-96ef-4c41-a060-3c7f92e3e8a1' class='xr-var-data-in' type='checkbox'><label for='data-b71adc7e-96ef-4c41-a060-3c7f92e3e8a1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Flight level</dd><dt><span>units :</span></dt><dd>hectofeet</dd></dl></div><div class='xr-var-data'><pre>array([270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400,\n",
+       "       410, 420, 430, 440], dtype=int32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2024-09-25T18:00:00</div><input id='attrs-20f3b6e2-a5d4-4020-acfb-acdedb55383e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-20f3b6e2-a5d4-4020-acfb-acdedb55383e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e92b50b2-719c-4794-a8ef-355116a31082' class='xr-var-data-in' type='checkbox'><label for='data-e92b50b2-719c-4794-a8ef-355116a31082' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2024-09-25T18:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>forecast_reference_time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2024-09-25T12:00:00</div><input id='attrs-2627cec1-965c-4a7a-ae4c-273dd2411d23' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2627cec1-965c-4a7a-ae4c-273dd2411d23' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5775bacd-5ee6-4ed8-8e96-4fdbe2af2adc' class='xr-var-data-in' type='checkbox'><label for='data-5775bacd-5ee6-4ed8-8e96-4fdbe2af2adc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2024-09-25T12:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1933c3c7-9cf0-4c43-90bc-84c78cfdbe33' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1933c3c7-9cf0-4c43-90bc-84c78cfdbe33' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>contrails</span></div><div class='xr-var-dims'>(longitude, latitude, flight_level, time)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0</div><input id='attrs-78c5d296-9043-4867-9a85-4a97ac4a4cc6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-78c5d296-9043-4867-9a85-4a97ac4a4cc6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cef977bc-d975-4182-bafc-3b455de8e10c' class='xr-var-data-in' type='checkbox'><label for='data-cef977bc-d975-4182-bafc-3b455de8e10c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Contrail forcing index</dd><dt><span>units :</span></dt><dd></dd><dt><span>valid_min :</span></dt><dd>0</dd><dt><span>valid_max :</span></dt><dd>4</dd></dl></div><div class='xr-var-data'><pre>array([[[[0.        ],\n",
        "         [0.        ],\n",
        "         [0.        ],\n",
        "         ...,\n",
@@ -495,37 +497,38 @@
        "         ...,\n",
        "         [0.        ],\n",
        "         [0.        ],\n",
-       "         [0.        ]]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ca9712dd-f548-4bd6-bde3-b05033bf24fb' class='xr-section-summary-in' type='checkbox'  ><label for='section-ca9712dd-f548-4bd6-bde3-b05033bf24fb' class='xr-section-summary' >Indexes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-f3017590-4d8f-41d9-bef6-eec4ac47e99c' class='xr-index-data-in' type='checkbox'/><label for='index-f3017590-4d8f-41d9-bef6-eec4ac47e99c' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -180.0, -179.75,  -179.5, -179.25,  -179.0, -178.75,  -178.5, -178.25,\n",
+       "         [0.        ]]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e3dd1da5-839d-42ac-9382-02dd7d1fab2f' class='xr-section-summary-in' type='checkbox'  ><label for='section-e3dd1da5-839d-42ac-9382-02dd7d1fab2f' class='xr-section-summary' >Indexes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-d75a794c-18fc-4101-8033-535ce60c393f' class='xr-index-data-in' type='checkbox'/><label for='index-d75a794c-18fc-4101-8033-535ce60c393f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -180.0, -179.75,  -179.5, -179.25,  -179.0, -178.75,  -178.5, -178.25,\n",
        "        -178.0, -177.75,\n",
        "       ...\n",
        "         177.5,  177.75,   178.0,  178.25,   178.5,  178.75,   179.0,  179.25,\n",
        "         179.5,  179.75],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;longitude&#x27;, length=1440))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-47b4a3b8-82bf-4733-8e47-f497efbd56b6' class='xr-index-data-in' type='checkbox'/><label for='index-47b4a3b8-82bf-4733-8e47-f497efbd56b6' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -80.0, -79.75,  -79.5, -79.25,  -79.0, -78.75,  -78.5, -78.25,  -78.0,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;longitude&#x27;, length=1440))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-c5a71849-747a-4fb7-9516-af893e4b6c53' class='xr-index-data-in' type='checkbox'/><label for='index-c5a71849-747a-4fb7-9516-af893e4b6c53' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -80.0, -79.75,  -79.5, -79.25,  -79.0, -78.75,  -78.5, -78.25,  -78.0,\n",
        "       -77.75,\n",
        "       ...\n",
        "        77.75,   78.0,  78.25,   78.5,  78.75,   79.0,  79.25,   79.5,  79.75,\n",
        "         80.0],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;latitude&#x27;, length=641))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>flight_level</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-9ba802ff-7158-4d33-8b73-baea908ae255' class='xr-index-data-in' type='checkbox'/><label for='index-9ba802ff-7158-4d33-8b73-baea908ae255' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;latitude&#x27;, length=641))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>flight_level</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-c1ae73cc-1c92-435d-8b35-3b98130795f4' class='xr-index-data-in' type='checkbox'/><label for='index-c1ae73cc-1c92-435d-8b35-3b98130795f4' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400,\n",
        "       410, 420, 430, 440],\n",
-       "      dtype=&#x27;int32&#x27;, name=&#x27;flight_level&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ab0fa5d5-2b04-4697-a90b-116ba0e51f9c' class='xr-index-data-in' type='checkbox'/><label for='index-ab0fa5d5-2b04-4697-a90b-116ba0e51f9c' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2024-09-25 18:00:00&#x27;], dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-114d6373-823c-4f36-8247-0181c9e13a3d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-114d6373-823c-4f36-8247-0181c9e13a3d' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>forecast_reference_time :</span></dt><dd>2024-09-25T12:00:00Z</dd><dt><span>aircraft_class :</span></dt><dd>default</dd><dt><span>model :</span></dt><dd>v1</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;int32&#x27;, name=&#x27;flight_level&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-9523656b-e742-4364-b5d0-4d3b9895db86' class='xr-index-data-in' type='checkbox'/><label for='index-9523656b-e742-4364-b5d0-4d3b9895db86' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2024-09-25 18:00:00&#x27;], dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-af0cf5f8-1af1-4222-9ab4-97c6d87fa6b6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-af0cf5f8-1af1-4222-9ab4-97c6d87fa6b6' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>aircraft_class :</span></dt><dd>default</dd><dt><span>model :</span></dt><dd>v1</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
-       "Dimensions:       (longitude: 1440, latitude: 641, flight_level: 18, time: 1)\n",
+       "Dimensions:                  (longitude: 1440, latitude: 641, flight_level: 18,\n",
+       "                              time: 1)\n",
        "Coordinates:\n",
-       "  * longitude     (longitude) float32 -180.0 -179.8 -179.5 ... 179.2 179.5 179.8\n",
-       "  * latitude      (latitude) float32 -80.0 -79.75 -79.5 ... 79.5 79.75 80.0\n",
-       "  * flight_level  (flight_level) int32 270 280 290 300 310 ... 410 420 430 440\n",
-       "  * time          (time) datetime64[ns] 2024-09-25T18:00:00\n",
+       "  * longitude                (longitude) float32 -180.0 -179.8 ... 179.5 179.8\n",
+       "  * latitude                 (latitude) float32 -80.0 -79.75 ... 79.75 80.0\n",
+       "  * flight_level             (flight_level) int32 270 280 290 ... 420 430 440\n",
+       "  * time                     (time) datetime64[ns] 2024-09-25T18:00:00\n",
+       "    forecast_reference_time  (time) datetime64[ns] 2024-09-25T12:00:00\n",
        "Data variables:\n",
-       "    contrails     (longitude, latitude, flight_level, time) float32 0.0 ... 0.0\n",
+       "    contrails                (longitude, latitude, flight_level, time) float32 ...\n",
        "Attributes:\n",
-       "    forecast_reference_time:  2024-09-25T12:00:00Z\n",
-       "    aircraft_class:           default\n",
-       "    model:                    v1"
+       "    aircraft_class:  default\n",
+       "    model:           v1"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -545,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "1a44dd22-683a-45ea-8174-e5f2b75e6414",
    "metadata": {},
    "outputs": [
@@ -580,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "2cac6d2f-0cdd-45b2-8847-778880bd98ca",
    "metadata": {},
    "outputs": [],
@@ -593,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "632a1242-a4f5-4f69-8789-7c82fd7f3b52",
    "metadata": {},
    "outputs": [

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -142,20 +142,6 @@ A 400 status code and informative message should be returned if:
 
 ### response headers
 
-The response header must populate the following values to contextualize the response data.
-*Populating these headers is imperative since the behavior of the API is not idempotent given the
-behavior mentioned above.*
-
-- `model_run_at` (`<%Y-%m-%dT%H:%M:%S>`): The analysis time of the forecast.
-  This is the same as the [*forecast_reference_time* as defined by CF conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.1Analysistime:theforecastreferencetime).
-- `model_prediction_at` (`<%Y-%m-%dT%H:%M:%S>`): The valid time of the model prediction,
-  i.e. it is the same as the `<ts>` value passed in the API call,
-  and the `time` of the data returned in the gridded netCDF.
-  This is the same as the [*valid time* as defined by CF Conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.3Validtime).
-- `model_forecast_hour` (`<int>`): The difference, in hours, between `model_predicted_at` and `model_run_at`.
-  It represents how far out the meteorological forecast is for a given model output.
-  This is similar to the [*forecast period* as defined by CF Conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.2Forecast:theforecastperiod).
-
 ### response object
 
 The netCDF object returned from the API represents contrail climate
@@ -181,7 +167,7 @@ Attributes:
     aircraft_class: "default"
 ```
 
-Note that `forecast_reference_time` in the dataset level *Attributes* has the same definition as
+Note that `forecast_reference_time` non-dimension coordinate has the same definition as
 `model_run_at` in the API response header.
 See the [Forecast Data spec](forecast-data.md) for more info.
 
@@ -195,6 +181,7 @@ Coordinates:
   * latitude   (latitude) float32 3kB -80.0 -79.75 -79.5 ... 79.5 79.75 80.0
   * flight_level      (flight_level) int16 2B 270
   * time       (time) datetime64[ns] 8B 2024-07-01T12:00:00
+    forecast_reference_time (time) datetime64[ns] 8B 2024-07-01T06:00:00
 Attributes:
     long_name:  'Contrail forcing index'
     units:      ''

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -105,7 +105,7 @@ and ordinal yet leave sufficient room for future expansion.
 
 ### timestamp
 
-The `ts` value has the form `%Y%m%d%H`. It is a required query parameter.
+The `{ts}` value has the form `%Y%m%d%H`. It is a required query parameter.
 This hour-resolution timestamp
 represents the target time of the model prediction ("predicted_at"
 time).

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -43,7 +43,7 @@ prototype contrail avoidance in air traffic decision support systems.
 The signature, behavior and design considerations of these two endpoints
 are detailed below.
 
-Future work, contingent upon the implementation of multiple aircraft classes,
+If/when multiple aircraft classes are implemented, future work may include a discovery/recommendation endpoint to
 may include adding a discovery/recommendation endpoint, to
 help consumers map aircraft configuration attributes to a recommended
 aircraft class. The materialization of such an endpoint requires

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -61,7 +61,7 @@ The `v1/grids` route returns pre-rendered netCDF assets.
 Request
 
 ```
-GET /v1/grids?aircraft_class={ac_id}&timestamp={ts}&flight_level={fl} HTTP/2
+GET /v1/grids?aircraft_class={ac_id}&time={ts}&flight_level={fl} HTTP/2
 Host: {TBD}
 Headers:
     x-api-key: {key}
@@ -72,9 +72,6 @@ Response
 ```
 Headers:
     content-type: application/netcdf
-    model_forecast_hour: <int>
-    model_prediction_at: <%Y-%m-%dT%H:%M:%S>
-    model_run_at: <%Y-%m-%dT%H:%M:%S>
 ```
 
 ### auth
@@ -114,7 +111,7 @@ Given that ECMWF delivers 73 hours of forecast data every 6 hours, it is
 expected that a given ts will have multiple candidate URIs to serve to a
 client.
 
-If multiple candidate URIs exist for a given timestamp at the time of
+If multiple candidate URIs exist for a given `time` at the instance of
 the client request, *the API should return the URI whose outputs were
 generated using the nearest forecast reference time.*
 
@@ -147,7 +144,7 @@ The fl value must be one of the following:
 A 400 status code and informative message should be returned if:
 
 - the provided flight level is not recognized
-- the provided timestamp is malformed
+- the provided time string is malformed
 - the provided aircraft class is not recognized
 - the request is properly formed and interpretable, but the requested resource does not exist
 
@@ -232,7 +229,7 @@ Same as [grids.auth](#auth)
 
 Same as [grids.aircraft_classes](#aircraft-classes)
 
-### timestamp
+### time
 
 Same as [grids.time](#time)
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -167,9 +167,6 @@ Attributes:
     aircraft_class: "default"
 ```
 
-Note that `forecast_reference_time` non-dimension coordinate has the same definition as
-`model_run_at` in the API response header.
-See the [Forecast Data spec](forecast-data.md) for more info.
 
 The `contrails` data variable has the following *Attributes*:
 

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -262,9 +262,7 @@ format:
             "timestamp": "<%Y-%m-%dT%H:%M:%S>",
             "flight_level": <int>,
             "threshold": <int>,
-            "model_forecast_hour": <int>,
-            "model_prediction_at": <%Y-%m-%dT%H:%M:%S>,
-            "model_run_at": <%Y-%m-%dT%H:%M:%S>
+            "forecast_reference_time": <%Y-%m-%dT%H:%M:%S>
         },
         "geometry": {
           "type": "MultiPolygon",
@@ -293,5 +291,5 @@ and adding `forcast_reference_time` and `aircraft_class` to the netCDF global at
 ## 2024.TBD
 - `/grids` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
 - `/grids` move `forecast_reference_time` to a non-dimension coordinate; remove `forecast_reference_time` from data-array attributes.
-- `/regions` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
+- `/regions` endpoint reworked to remove header k-vs, and add `forecast_reference_time` to `Feature` properties. `aircraft_class` is documented, but optional.
 - `/regions` geoJSON response object updated to include resource-identifying attributes in the `"properties"` object for the geoJSON `Feature`.

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -150,6 +150,8 @@ A 400 status code and informative message should be returned if:
 
 ### response headers
 
+No custom response headers.
+
 ### response object
 
 The netCDF object returned from the API represents contrail climate
@@ -252,6 +254,7 @@ The threshold value provided by the client must be one of the following:
 Same as [grids.error_handling](#error-handling)
 
 ## response headers
+
 Same as [grids.response_headers](#response-headers)
 
 ### response object
@@ -301,4 +304,4 @@ and adding `forcast_reference_time` and `aircraft_class` to the netCDF global at
 - `/grids` move `forecast_reference_time` to a non-dimension coordinate; remove `forecast_reference_time` from data-array attributes.
 - `/regions` endpoint reworked to remove header k-vs. `aircraft_class` is documented, but optional.
 - `/regions` geoJSON response object updated to include resource-identifying attributes in the `"properties"` object for the geoJSON `Feature`.
-- `/grids` and `/regions` to take a query param `time` (renamed from `timestamp`), with updated handling/interpretation (see [###time](#time) section)
+- `/grids` and `/regions` to take a query param `time` (renamed from `timestamp`), with updated handling/interpretation (see [time](#time) section)

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -120,7 +120,7 @@ generated using the nearest forecast time.
 
 ### flight level
 
-The {fl} value represents the flight level (*hectofeet*) of the returned
+The `{fl}` value represents the flight level (*hectofeet*) of the returned
 netCDF global grid. It is a required query parameter.
 
 The fl value must be one of the following:

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -120,7 +120,7 @@ generated using the nearest forecast time.
 
 ### flight level
 
-The fl value represents the flight level (*hectofeet*) of the returned
+The {fl} value represents the flight level (*hectofeet*) of the returned
 netCDF global grid. It is a required query parameter.
 
 The fl value must be one of the following:

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -21,7 +21,7 @@ availability.
     80\] (this is expected to expand and encompass the poles, with an
     update at a later time). These grids are available across several
     [aircraft classes](#aircraft-classes); only the `default` aircraft class is served until 
-    there is sufficient customer evidence to suggest needing the implementation of additional aircraft classes. 
+    there is sufficient evidence and agreement to implement additional aircraft classes. 
     The variable returned in the netCDF
     is `contrails`, a domain-agnostic quantity of arbitrary units,
     existing in the range of \[0, 4]\, `0` being a location with no contrail impact,

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -174,10 +174,10 @@ Coordinates:
   * latitude   (latitude) float32 3kB -80.0 -79.75 -79.5 ... 79.5 79.75 80.0
   * flight_level      (flight_level) int16 2B 300
   * time       (time) datetime64[ns] 8B 2024-07-01T12:00:00
+    forecast_reference_time (time) datetime64[ns] 8B 2024-07-01T06:00:00
 Data variables:
     contrails   (longitude, latitude, flight_level, time) float32 4MB ...
 Attributes:
-    forecast_reference_time:  "2024-07-01T06:00:00Z"
     aircraft_class: "default"
 ```
 
@@ -308,5 +308,6 @@ and adding `forcast_reference_time` and `aircraft_class` to the netCDF global at
 
 ## 2024.TBD
 - `/grids` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
+- `/grids` move `forecast_reference_time` to a non-dimension coordinate; remove `forecast_reference_time` from data-array attributes.
 - `/regions` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
 - `/regions` geoJSON response object updated to include resource-identifying attributes in the `"properties"` object for the geoJSON `Feature`.

--- a/docs/specs/forecast-api.md
+++ b/docs/specs/forecast-api.md
@@ -307,6 +307,6 @@ and adding `forcast_reference_time` and `aircraft_class` to the netCDF global at
 - `/regions` geoJSON response object format updated from `.features.*` to `.features[].*`.
 
 ## 2024.TBD
-- `/grids` endpoint reworked to move all path parameters to query parameters
-- `/regions` endpoint reworked to move all path parameters to query parameters
+- `/grids` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
+- `/regions` endpoint reworked to move all path parameters to query parameters. `aircraft_class` is documented, but optional.
 - `/regions` geoJSON response object updated to include resource-identifying attributes in the `"properties"` object for the geoJSON `Feature`.

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -13,10 +13,6 @@ This document assumes data is stored in a `netCDF4` format.
 Forecast must be globally valid for the same `forecast_reference_time`.
 
 ## Global Attributes
-
-- `forecast_reference_time` (`str`): The forecast reference time is the "data time",
-i.e. the time at which the meteorological model was executed for a given set of forecast times.
-Reported in ISO 8601 `"YYYY-MM-DDTHH:MM:SSZ"` e.g. `"2024-10-07T01:00:00Z"`.
 - (optional) `aircraft_class` (`str`): Aircraft class for forecast.
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 - (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
@@ -28,8 +24,10 @@ Additional attributes, in addition to the required and suggested ones above, may
 - `longitude` (`float32`): `np.arange(-180, 180, 0.25)`, EPSG:4326
 - `latitude` (`float32`): `np.arange(-90, 90, 0.25)`, EPSG:4326
 - `flight_level` (`int16` or `int32`): `[270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400, 410, 420, 430, 440]`, hectofeet [^flightlevels]
-- `time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate). Must have `units` and `calendar` variable attributes. e.g.
+- `time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate).
+- `forecast_reference_time` (`int32` or `int64`): The forecast reference time is the "data time", i.e. the time at which the meteorological model was executed for a given set of forecast times.`
 
+💡 Both `time` and `forecast_reference_time` must have `units` and `calendar` variable attributes. e.g.
 	```
 	units: hours since 2022-12-12
 	calendar: proleptic_gregorian

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -10,9 +10,10 @@ This document assumes data is stored in a `netCDF4` format.
 
 ## Domain
 
-Forecast must be globally valid for the same `forecast_reference_time`.
+Forecast must be globally valid for each `forecast_reference_time`.
 
 ## Global Attributes
+
 - (optional) `aircraft_class` (`str`): Aircraft class for forecast.
 One of \[`"low_e"`, `"default"`, `"high_e"`\], where suffix `_e` references *emissions*.[^emissions]
 - (optional) `model` (`str`): A descriptor of the model used in generating the `contrails` variable.
@@ -24,16 +25,30 @@ Additional attributes, in addition to the required and suggested ones above, may
 - `longitude` (`float32`): `np.arange(-180, 180, 0.25)`, EPSG:4326
 - `latitude` (`float32`): `np.arange(-90, 90, 0.25)`, EPSG:4326
 - `flight_level` (`int16` or `int32`): `[270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400, 410, 420, 430, 440]`, hectofeet [^flightlevels]
-- `time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate).
-- `forecast_reference_time` (`int32` or `int64`): The forecast reference time is the "data time", i.e. the time at which the meteorological model was executed for a given set of forecast times. See [*forecast_reference_time* as defined by CF conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.1Analysistime:theforecastreferencetime)
+- `time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate). See [time dimensions](#time-dimensions) for more details.
+- `forecast_reference_time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate). The forecast reference time is the "data time", i.e. the time at which the meteorological model was executed for each forecast `time` value. See [*forecast_reference_time* as defined by CF conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.1Analysistime:theforecastreferencetime). See [time dimensions](#time-dimensions) for more details.
 
-💡 Both `time` and `forecast_reference_time` must have `units` and `calendar` variable attributes. e.g.
-	```
-	units: hours since 2022-12-12
-	calendar: proleptic_gregorian
-	```
+### Time dimensions
 
-> In general we use `xarray` to encode times directly from `np.datetime64` to CF compatible format. See [xarray Time Units](https://docs.xarray.dev/en/stable/user-guide/io.html#time-units) for more information.
+[CF conventions](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate) require
+both `time` and `forecast_reference_time` have `units` and `calendar` variable attributes, e.g.:
+
+```
+units: hours since 2022-12-12
+calendar: proleptic_gregorian
+```
+
+When reading or writing netCDF files with [xarray](https://docs.xarray.dev/en/stable), `xarray`
+automatically decodes/encodes datetime arrays using CF conventions
+When reading, `xarray` will decode datetime arrays directly into a `np.datetime64` array and hide the
+`units` and `calendar` attributes.
+When writing, `xarray` uses the `'proleptic_gregorian'` calendar and `units` of the smallest
+time difference between values, with a reference time of the first time value.
+See [xarray Time Units](https://docs.xarray.dev/en/stable/user-guide/io.html#time-units) for more information.
+
+Its valid to write `time` and `forecast_reference_time` as unix time integers, but
+`units` must still be specified as `"seconds since 1970-01-01 00:00:00"`.
+`calendar` attribute may still be specified to define the set of dates (year-month-day combinations) which are permitted.
 
 ## Variables
 

--- a/docs/specs/forecast-data.md
+++ b/docs/specs/forecast-data.md
@@ -25,7 +25,7 @@ Additional attributes, in addition to the required and suggested ones above, may
 - `latitude` (`float32`): `np.arange(-90, 90, 0.25)`, EPSG:4326
 - `flight_level` (`int16` or `int32`): `[270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400, 410, 420, 430, 440]`, hectofeet [^flightlevels]
 - `time` (`int32` or `int64`): [CF compatible time coordinates](https://cfconventions.org/cf-conventions/cf-conventions#time-coordinate).
-- `forecast_reference_time` (`int32` or `int64`): The forecast reference time is the "data time", i.e. the time at which the meteorological model was executed for a given set of forecast times.`
+- `forecast_reference_time` (`int32` or `int64`): The forecast reference time is the "data time", i.e. the time at which the meteorological model was executed for a given set of forecast times. See [*forecast_reference_time* as defined by CF conventions](https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.3.1Analysistime:theforecastreferencetime)
 
 💡 Both `time` and `forecast_reference_time` must have `units` and `calendar` variable attributes. e.g.
 	```


### PR DESCRIPTION
## Changes
This refactors the `/regions` and `/grids` signatures and expected behavior.

See the Changelog notes.

GeoJSON response object is also augmented with per-features attributes, meant to localize resource identifying values.  This change opens the door to future feature expansion of the `regions` endpoint, specifically aggregation of geoJSON Features across flight-levels and/or time and/or aircraft class.

Similarly, the netCDF response object is refactored to move the `forecast_reference_time` from a data-array-wide attribute to a non-dimension coordinate, effectively allowing for a future case where multiple slices of `time` are returned, each with a difference corresponding `forecast_reference_time`.

## Refs

These contractual changes are staged for deployment in the **api-preprocessor**, [PR HERE](https://github.com/contrailcirrus/api-preprocessor/pull/77) and in the **contrails-api** [PR HERE](https://github.com/contrailcirrus/contrails-api/pull/152).
